### PR TITLE
Fixing alignment routines, both linear-space and quadratic-space

### DIFF
--- a/Source/mesquite/align/lib/AlignmentHelperLinearSpace.java
+++ b/Source/mesquite/align/lib/AlignmentHelperLinearSpace.java
@@ -117,8 +117,6 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 	
 	public void fillForward(int firstRow, int lastRow, int firstColumn, int lastColumn, int shape) {
 		
-		//int lengthA = lastRow - firstRow + 1;
-		//int lengthB = lastColumn - firstColumn + 1;
 		int i,j;
 		
 		int gapExtendOnB, gapExtendOnA;
@@ -132,14 +130,14 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 		} else if ( shape == gapInB) {
 			fV[firstColumn] = 0;
 		}
-		
-		//fill row-by-row. First row is a special case 
-		gapExtendOnA = (0==firstRow || lengthB==firstRow) ? gapExtendTerminal : gapExtend ;		
-		for (j=firstColumn+1; j<=lastColumn; j++) {			
+
+		//fill row-by-row. First row is a special case
+		gapExtendOnA = (0==firstRow || lengthA==firstRow) ? gapExtendTerminal : gapExtend ;
+		for (j=firstColumn+1; j<=lastColumn; j++) {
 			fD[j] = fV[j] = bigNumber;
-			fH[j] = fH[firstColumn] + gapExtendOnA*(j-firstColumn);		
-		}
-		
+			fH[j] = fH[j-1] + gapExtendOnA;
+        }
+
 
 		int tmp1H, tmp1D, tmp1V, tmp2H, tmp2D, tmp2V;
 	//reuse the arrays, treating it as the next row in the DP table. Keep one temp variable for each array
@@ -169,40 +167,38 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 				if (isMinimize) {
 					fV[j] = Math.min(  fH[j] + gapOpenOnB + gapExtendOnB,  
 							Math.min ( fD[j]  + gapOpenOnB + gapExtendOnB ,
-											 fV[j] + gapExtendOnB));
+									   fV[j] + gapExtendOnB));
 
 					fH[j] = Math.min(  fH[j-1] + gapExtendOnA,  
-								Math.min ( fD[j-1] + gapOpenOnA + gapExtendOnA,
-												 fV[j-1] + gapOpenOnA + gapExtendOnA));
+							Math.min ( fD[j-1] + gapOpenOnA + gapExtendOnA,
+					  				   fV[j-1] + gapOpenOnA + gapExtendOnA));
 	
 					fD[j] = AlignUtil.getCost(subs,A[i-1],B[j-1],alphabetLength) +  Math.min(  tmp1H, Math.min ( tmp1D , tmp1V));
 				} else { //maximize
 					fV[j] = Math.max(  fH[j] + gapOpenOnB + gapExtendOnB,  
 							Math.max ( fD[j] + gapOpenOnB + gapExtendOnB ,
-											 fV[j] + gapExtendOnB));					
+									   fV[j] + gapExtendOnB));
 					
 					fH[j] = Math.max(  fH[j-1] + gapExtendOnA,  
-								Math.max( fD[j-1] + gapOpenOnA + gapExtendOnA,
-												fV[j-1] + gapOpenOnA + gapExtendOnA));
+							Math.max(  fD[j-1] + gapOpenOnA + gapExtendOnA,
+									   fV[j-1] + gapOpenOnA + gapExtendOnA));
 					
 					fD[j] = AlignUtil.getCost(subs,A[i-1],B[j-1],alphabetLength) +  Math.max(  tmp1H , Math.max( tmp1D, tmp1V ));
 				}
+
 				tmp1H = tmp2H;
 				tmp1D = tmp2D;
 				tmp1V = tmp2V;
 			}
 		}
-		
-		
-		
 	}
+
 	public void fillReverse(int firstRow, int lastRow, int firstColumn, int lastColumn, int shape) {
 
 	    int i,j;
 		int gapExtendOnA;
 		int gapOpenOnA;	
-		
-		
+
 		rH[lastColumn] = rV[lastColumn] = (lengthB==lastColumn) ? gapOpenTerminal : gapOpen;;
 		rD[lastColumn] = 0;
 		
@@ -213,10 +209,10 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 		}
 		
 		//fill row-by-row. Last row is a special case 
-		gapExtendOnA = (0==lastRow || lengthB==lastRow) ? gapExtendTerminal : gapExtend ;
+		gapExtendOnA = (0==lastRow || lengthA==lastRow) ? gapExtendTerminal : gapExtend ;
 		for (j=lastColumn-1; j>=firstColumn; j--) {
 			rD[j] = rV[j] = bigNumber;
-			rH[j] = rH[lastColumn] + gapExtendOnA*(lastColumn-j);
+            rH[j] = rH[j+1] + gapExtendOnA;
 		}
 		
 		int tmp1H, tmp1D, tmp1V, tmp2H, tmp2D, tmp2V;
@@ -226,7 +222,7 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 			tmp1D = rD[lastColumn];
 			tmp1V = rV[lastColumn];
 
-			rD[lastColumn] = rH[lastColumn] = bigNumber;
+			rD[lastColumn] = rH[lastColumn] = bigNumber ;
 			rV[lastColumn] +=  (0==lastColumn || lengthB==lastColumn) ? gapExtendTerminal : gapExtend ;
 			
 			gapOpenOnA =  (0==i) ? gapOpenTerminal : gapOpen;
@@ -283,11 +279,11 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 		fillArrays(firstRow, lastRow, firstColumn, lastColumn, precedingShape, succeedingShape );
 		
 		int midRow = (firstRow + lastRow)/2;  //in seqA
-		
+
 		int i, verticalColScore, diagonalColScore; 
 		int bestColScore = bigNumber , bestCol = -1, bestColShape = noGap;
-		for (i=firstColumn; i<=lastColumn; i++) {			
-			gapOpenOnB =  (0==i || lengthB==i) ? gapOpenTerminal : gapOpen;
+		for (i=firstColumn; i<=lastColumn; i++) {
+			gapOpenOnB  =  (0==i || lengthB==i) ? gapOpenTerminal : gapOpen;
 			gapExtendOnB = (0==i || lengthB==i) ? gapExtendTerminal : gapExtend ;
 			// best of the ways of leaving the i,j cell of the full DP table with a vertical edge 
 			verticalColScore = Math.min(fH[i] + rH[i] + gapExtendOnB + gapOpenOnB,
@@ -310,11 +306,10 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 				int b = B[i];
 				int s = AlignUtil.getCost(subs,a,b,alphabetLength);
 				diagonalColScore = Math.min(fH[i], Math.min (fD[i], fV[i])) +
-										Math.min(rH[i+1], Math.min (rD[i+1], rV[i+1])) +
-										s;
+								   Math.min(rH[i+1], Math.min (rD[i+1], rV[i+1])) +
+								   s;
 			}
 			// no need to track horizontal edges - those are already stored in the forward and reverse arrays
-			
 			if (verticalColScore < diagonalColScore) {
 				if ( verticalColScore < bestColScore) {
 					bestColScore = verticalColScore;
@@ -333,6 +328,7 @@ public class AlignmentHelperLinearSpace extends AlignmentHelper {
 		lastB_BeforeNextA[midRow] = bestCol;
 		shapeLeavingPosInA[midRow] = bestColShape;
 				
+
 		//	Recurse to find the full list of cells through which the alignment passes.
 		if ( firstRow != midRow){
 			recursivelyFillArray(firstRow, midRow, firstColumn, bestCol, precedingShape, bestColShape);

--- a/Source/mesquite/align/lib/PairwiseAligner.java
+++ b/Source/mesquite/align/lib/PairwiseAligner.java
@@ -181,14 +181,15 @@ public class PairwiseAligner  {
 				int myScore =  helper.recursivelyFillArray(0, lengthA, 0, lengthB, helper.noGap, helper.noGap);
 				ret = helper.recoverAlignment(totalGapChars, seqsWereExchanged);
 				gapInsertionArray = helper.getGapInsertionArray();  
-
+	            if (score != null)
+	                score.setValue( myScore );
 			} else {
 //				 fast (but quadratic space) alignment
 			    AlignmentHelperQuadraticSpace helper = new AlignmentHelperQuadraticSpace(A, B, lengthA, lengthB, subs, gO, gE, gOt, gEt, alphabetLength);
 				ret = helper.doAlignment(returnAlignment,score,keepGaps, followsGapSize, totalGapChars);
 				gapInsertionArray = helper.getGapInsertionArray();
 			}
-		
+
 			if (ret==null)
 				return null;
 			for (int i=0; i<ret.length; i++) {
@@ -213,10 +214,9 @@ public class PairwiseAligner  {
 				return null;
 			}
 			//linear space, and since it only makes one pass, it's the fastest option for score-only requests.
-			AlignmentHelperLinearSpace helper = new AlignmentHelperLinearSpace(A, B, lengthA, lengthB, subs, gO, gE, alphabetLength, true, keepGaps, followsGapSize);
+			AlignmentHelperLinearSpace helper = new AlignmentHelperLinearSpace(A, B, lengthA, lengthB, subs, gO, gE, gOt, gEt, alphabetLength, true, keepGaps, followsGapSize);
 			helper.fillForward(0,lengthA,0,lengthB,helper.noGap);			
-			int myScore = Math.min(helper.fH[lengthA], Math.min (helper.fD[lengthA], helper.fV[lengthA])) ;
-			
+			int myScore = Math.min(helper.fH[lengthB], Math.min (helper.fD[lengthB], helper.fV[lengthB])) ;
 			if (score != null)
 				score.setValue( myScore );
 


### PR DESCRIPTION
(1) Fixed an edge-case in the linear-space aligner, in which fillBackward
failed to correctly set the terminal gap costs, because of the used of
the wrong test condition (lengthB should've been LengthA).

(2) Fixed unrelated bugs that also affected terminal gaps in the
quadratic-space aligner: (a) terminal costs weren't being correctly passed
in to the aligner, and (b) and the values for the first row and column of
the DP table were not correctly scoring impossible cells.
