### PR TITLE
Modified ExternalSequencerAligner now uses ShellScriptRunner

### DIFF
--- a/Source/mesquite/lib/MesquiteModule.java
+++ b/Source/mesquite/lib/MesquiteModule.java
@@ -90,7 +90,7 @@ public abstract class MesquiteModule extends EmployerEmployee implements Command
 	public final static int getBuildNumber() {
 		//as of 26 Dec 08, build naming changed from letter + number to just number.  Accordingly j105 became 473, based on
 		// highest build numbers of d51+e81+g97+h66+i69+j105 + 3 for a, b, c
-		return 	790;  
+		return 	791;  
 	}
 	//0.95.80    14 Mar 01 - first beta release 
 	//0.96  2 April 01 beta  - second beta release


### PR DESCRIPTION
ExternalSequencerAligner was not functioning on Windows 7.  Not sure why it wasn't working, but I switched it to use ShellScriptRunner, and it now works.