### PR TITLE
Show Chart now functional in project panel popups

### DIFF
--- a/Source/mesquite/lib/MesquiteModule.java
+++ b/Source/mesquite/lib/MesquiteModule.java
@@ -68,7 +68,7 @@ public abstract class MesquiteModule extends EmployerEmployee implements Command
 	/*.................................................................................................................*/
 	/** returns build date of the Mesquite system (e.g., "22 September 2003") */
 	public final static String getBuildDate() {
-		return "5 November 2016";
+		return "6 November 2016";
 	}
 	/*.................................................................................................................*/
 	/** returns version of the Mesquite system */
@@ -90,7 +90,7 @@ public abstract class MesquiteModule extends EmployerEmployee implements Command
 	public final static int getBuildNumber() {
 		//as of 26 Dec 08, build naming changed from letter + number to just number.  Accordingly j105 became 473, based on
 		// highest build numbers of d51+e81+g97+h66+i69+j105 + 3 for a, b, c
-		return 	793;  
+		return 	794;  
 	}
 	//0.95.80    14 Mar 01 - first beta release 
 	//0.96  2 April 01 beta  - second beta release

--- a/Source/mesquite/lib/ProjPanelPanel.java
+++ b/Source/mesquite/lib/ProjPanelPanel.java
@@ -175,7 +175,7 @@ public void resetTitle(){
 	public ClosablePanel getPrecedingPanel(ClosablePanel panel){
 		return null;
 	}
-	void chart(){  //to be overridden to respond to command to chart the element
+	public void chart(){  //to be overridden to respond to command to chart the element
 	}
 	public void changed(Object caller, Object obj, Notification notification){
 			refresh();

--- a/Source/mesquite/minimal/BasicFileCoordinator/ProjectWindow.java
+++ b/Source/mesquite/minimal/BasicFileCoordinator/ProjectWindow.java
@@ -1085,7 +1085,7 @@ class TaxaPanel extends ElementPanel {
 	public int requestSpacer(){
 		return 16;
 	}
-	void chart(){
+	public void chart(){
 		String mID = Long.toString(((FileElement)element).getID());
 		MesquiteThread.addHint(new MesquiteString("TaxonValuesChart", mID));
 		if (MesquiteDialog.useWizards)
@@ -1204,7 +1204,7 @@ class MElementPanel extends ElementPanel {
 
 	}
 
-	void chart(){
+	public void chart(){
 		String mID = Long.toString(((FileElement)element).getID());
 		String tID = Long.toString(((CharacterData)element).getTaxa().getID());
 		MesquiteThread.addHint(new MesquiteString("CharacterValuesChart", tID));
@@ -1285,7 +1285,7 @@ class TreesRPanel extends ElementPanel {
 	public String getElementTypeName(){ 
 		return "Trees Block";
 	}
-	void chart(){
+	public void chart(){
 		String mID = Long.toString(((TreeVector)element).getID());
 		String tID = Long.toString(((TreeVector)element).getTaxa().getID());
 		MesquiteThread.addHint(new MesquiteString("TreeValuesChart", tID));


### PR DESCRIPTION
Charts could not be invoked in project panel as the chart() method was not public, and thus the overrides were not available.  Fixed simply by making them public.