### PR TITLE
Lite Refactor of PhoneHomeThread

### DIFF
--- a/Source/mesquite/trunk/PhoneHomeThread.java
+++ b/Source/mesquite/trunk/PhoneHomeThread.java
@@ -62,7 +62,11 @@ public class PhoneHomeThread extends Thread {
 					BaseHttpRequestMaker.sendInfoToServer(beans.elementAt(0), MesquiteModule.beansReportURL, null, 0);
 					beans.removeElementAt(0);
 				}
-			} catch (Throwable e) { // TODO Catch and handle
+			} catch (InterruptedException e) { // Kill thread if Interrupted
+				MesquiteTrunk.mesquiteTrunk.logln("PhoneHomeThread was interrupted");
+				e.printStackTrace();
+				break;
+			} catch (Throwable e) { // TODO Catch and handle exceptions from BaseHttpRequestMaker
 			}
 		}
 	}

--- a/Source/mesquite/trunk/PhoneHomeThread.java
+++ b/Source/mesquite/trunk/PhoneHomeThread.java
@@ -31,70 +31,71 @@ import mesquite.lib.PhoneHomeUtil;
 import mesquite.lib.StringUtil;
 import mesquite.tol.lib.BaseHttpRequestMaker;
 
-/** Phone Home to mesquite server.
- *  At thread startup, PhoneHomeThread will report the mesquite version to the
- *  Mesquite server. It will then proceed to query the mesquite server for any 
- *  information about the installed module.
- *  
- *  After the initial startup, Phone Home thread will attempt to post any 
- *  "beans" to the mesquite server every ten seconds
+/**
+ * Phone Home to mesquite server. At thread startup, PhoneHomeThread will report
+ * the mesquite version to the Mesquite server. It will then proceed to query
+ * the mesquite server for any information about the installed module.
+ * 
+ * After the initial startup, Phone Home thread will attempt to post any "beans"
+ * to the mesquite server every ten seconds
  */
 public class PhoneHomeThread extends Thread {
 	// TODO use generics
 	Vector beans = new Vector();
 
-	public PhoneHomeThread () {
+	public PhoneHomeThread() {
 		setPriority(Thread.MIN_PRIORITY);
 	}
 
 	@Override
 	public void run() {
-		/* TODO Make this call non-blocking so the phone home thread does not 
-		 * hang if website is unavailable */
+		/*
+		 * TODO Make this call non-blocking so the phone home thread does not hang if
+		 * website is unavailable
+		 */
 		checkForMessagesFromAllHomes();
 
 		// Report beans to the mesqutie server
-		while (!MesquiteTrunk.mesquiteExiting) { 
+		while (!MesquiteTrunk.mesquiteExiting) {
 			try {
 				Thread.sleep(1000);
 				if (beans.size() > 0) {
-					NameValuePair[] b = (NameValuePair[])beans.elementAt(0);
+					NameValuePair[] b = (NameValuePair[]) beans.elementAt(0);
 					beans.removeElementAt(0);
 					BaseHttpRequestMaker.sendInfoToServer(b, MesquiteModule.beansReportURL, null, 0);
 				}
-			}
-			catch (Throwable e){
+			} catch (Throwable e) {
 			}
 		}
 	}
 
-	public void postBean(NameValuePair[] pairs){
-		beans.addElement(pairs);
+	public void postBean(NameValuePair[] pairs) {
+		beans.addElement(pairs); // TODO use generics
 	}
 
-	/** Reports version to Mesquite server and checks for information about
-	 * installed modules  
+	/**
+	 * Reports version to Mesquite server and checks for information about installed
+	 * modules
 	 */
-	public void checkForMessagesFromAllHomes(){
+	public void checkForMessagesFromAllHomes() {
 		// Report Version to server
 		try {
-			if (!MesquiteTrunk.suppressVersionReporting){
+			if (!MesquiteTrunk.suppressVersionReporting) {
 				StringBuffer response = new StringBuffer();
 				String buildNum = Integer.toString(MesquiteTrunk.getBuildNumber());
 				if (MesquiteTrunk.mesquiteTrunk.isPrerelease())
 					buildNum = "PreRelease-" + buildNum;
 				BaseHttpRequestMaker.contactServer(buildNum, MesquiteModule.versionReportURL, response);
 				String r = response.toString();
-				if (!StringUtil.blank(r) && r.indexOf("mq3rs")>=0){
-					if (r.indexOf("mq3rsshow")>=0){  //show dialog at startup!!!!
-						AlertDialog.noticeHTML(MesquiteTrunk.mesquiteTrunk.containerOfModule(),"Note", r, 600, 400, null);
+				if (!StringUtil.blank(r) && r.indexOf("mq3rs") >= 0) {
+					if (r.indexOf("mq3rsshow") >= 0) { // show dialog at startup!!!!
+						AlertDialog.noticeHTML(MesquiteTrunk.mesquiteTrunk.containerOfModule(), "Note", r, 600, 400,
+								null);
 					}
-				}
-				else if (MesquiteTrunk.debugMode)
+				} else if (MesquiteTrunk.debugMode)
 					MesquiteMessage.warnProgrammer("no response or incorrect response from server on startup");
 			}
-		}
-		catch (Throwable t){
+		} catch (Throwable t) {
 			if (MesquiteTrunk.debugMode)
 				MesquiteMessage.warnProgrammer("PROBLEM PHONING HOME to report version\n" + t.getCause());
 		}
@@ -103,26 +104,26 @@ public class PhoneHomeThread extends Thread {
 		ListableVector phoneRecords = new ListableVector();
 		StringBuffer notices = new StringBuffer();
 		StringBuffer logBuffer = new StringBuffer();
-		String path  = MesquiteModule.prefsDirectory+ MesquiteFile.fileSeparator+ "phoneRecords.xml";
+		String path = MesquiteModule.prefsDirectory + MesquiteFile.fileSeparator + "phoneRecords.xml";
 		PhoneHomeUtil.readOldPhoneRecords(path, phoneRecords);
-		for (int i= 0; i<MesquiteTrunk.mesquiteModulesInfoVector.size(); i++){
-			MesquiteModuleInfo mmi = (MesquiteModuleInfo)MesquiteTrunk.mesquiteModulesInfoVector.elementAt(i);
+		for (int i = 0; i < MesquiteTrunk.mesquiteModulesInfoVector.size(); i++) {
+			MesquiteModuleInfo mmi = (MesquiteModuleInfo) MesquiteTrunk.mesquiteModulesInfoVector.elementAt(i);
 			if (!StringUtil.blank(mmi.getHomePhoneNumber())) {
 				try {
-					int rec = phoneRecords.indexOfByName("#" + mmi.getClassName()); 
-					if (MesquiteTrunk.debugMode){
-						MesquiteTrunk.mesquiteTrunk.logln("Checking server for notices regarding " + mmi.getPackageName());
+					int rec = phoneRecords.indexOfByName("#" + mmi.getClassName());
+					if (MesquiteTrunk.debugMode) {
+						MesquiteTrunk.mesquiteTrunk
+								.logln("Checking server for notices regarding " + mmi.getPackageName());
 					}
-					
+
 					PhoneHomeRecord phoneHomeRecord;
-					if (!MesquiteInteger.isCombinable(rec) || rec<0) {// this module is not the phone records 
-						phoneHomeRecord = new PhoneHomeRecord("#"+mmi.getClassName());
+					if (!MesquiteInteger.isCombinable(rec) || rec < 0) {// this module is not the phone records
+						phoneHomeRecord = new PhoneHomeRecord("#" + mmi.getClassName());
 						phoneRecords.addElement(phoneHomeRecord, false);
-					}
-					else
-						phoneHomeRecord = (PhoneHomeRecord)phoneRecords.elementAt(rec);
+					} else
+						phoneHomeRecord = (PhoneHomeRecord) phoneRecords.elementAt(rec);
 					String notice = PhoneHomeUtil.retrieveMessagesFromHome(mmi, phoneHomeRecord, logBuffer);
-					
+
 					phoneHomeRecord.setCurrentValues(mmi);
 					if (!StringUtil.blank(notice)) {
 						if (mmi.getModuleClass() == mesquite.Mesquite.class)
@@ -133,30 +134,29 @@ public class PhoneHomeThread extends Thread {
 							notices.append("<h3>From " + mmi.getName() + "</h3>");
 						notices.append(notice);
 					}
-				}
-				catch (Throwable t){
+				} catch (Throwable t) { // TODO catch and handle errors explicitly
 				}
 			}
 		}
 
 		// Print Notices to console
-		if (!StringUtil.blank(logBuffer.toString())){
-			MesquiteTrunk.mesquiteTrunk.logln("\n*************************" + logBuffer.toString() + "\n*************************\n");
+		if (!StringUtil.blank(logBuffer.toString())) {
+			MesquiteTrunk.mesquiteTrunk
+					.logln("\n*************************" + logBuffer.toString() + "\n*************************\n");
 		}
-		if (!StringUtil.blank(notices)){
-			String note = ("<h2>Notices from the websites of Mesquite and installed packages</h2><hr>" + notices.toString() + "<br><h4>(You can ask Mesquite not to check for messages on its websites using the menu item in the Defaults submenu of the File menu)</h4>");
-			if (!MesquiteThread.isScripting()){
-				AlertDialog.noticeHTML(MesquiteTrunk.mesquiteTrunk.containerOfModule(),"Note", note, 600, 400, PhoneHomeUtil.getPhoneHomeDialogLinkCommand(), true);
-			}
-			else
+		if (!StringUtil.blank(notices)) {
+			String note = ("<h2>Notices from the websites of Mesquite and installed packages</h2><hr>"
+					+ notices.toString()
+					+ "<br><h4>(You can ask Mesquite not to check for messages on its websites using the menu item in the Defaults submenu of the File menu)</h4>");
+			if (!MesquiteThread.isScripting()) {
+				AlertDialog.noticeHTML(MesquiteTrunk.mesquiteTrunk.containerOfModule(), "Note", note, 600, 400,
+						PhoneHomeUtil.getPhoneHomeDialogLinkCommand(), true);
+			} else
 				System.out.println(note);
 		}
-		if (phoneRecords.size()>0)
+		if (phoneRecords.size() > 0)
 			PhoneHomeUtil.writePhoneRecords(path, phoneRecords);
 		MesquiteTrunk.mesquiteTrunk.storePreferences();
 		MesquiteTrunk.resetAllMenuBars();
 	}
 }
-
-
-

--- a/Source/mesquite/trunk/PhoneHomeThread.java
+++ b/Source/mesquite/trunk/PhoneHomeThread.java
@@ -76,8 +76,8 @@ public class PhoneHomeThread extends Thread {
 	}
 
 	/**
-	 * Reports version to Mesquite server and checks for information mesquite about
-	 * installed modules
+	 * Reports version to Mesquite server and checks for information about mesquite
+	 * and installed modules
 	 */
 	public void checkForMessagesFromAllHomes() {
 		// Report Version to server


### PR DESCRIPTION
This is an example of the initial lite refactoring that I think we should start with to improve the stability and readability of Mesquite. I am new to the codebase so please let me know if I am missing something here

Heres a short summary of the changes made:

1) **formatted using the default Eclipse formatting tools** 
This added `@Override` annotation and explicit imports, shortened some lines where it could, and formatted block comments. I think it is a good idea to use the default Eclipse formatting tools going forward to keep the codebase consistent, which makes it easier to read

2) **javadoc comments**
I've added javadoc comments to the methods so reading the code in an IDE or javadoc browser is easier. It appears that there is some convention with the long `/*---------*/` comments.  I am not sure if these are used by an automatic documentation parser. I replaced them in favor of javadoc. 

3) **Made the `beans` vector typed** 
This will ensure type safety at compile time so there are not any hidden/unexpected runtime errors. Generics are supported by everything including and after J2SE 5.0 which came out in 2004, so I think we will not have to worry about backwards compatibility in new releases

4) **Flattened the code**
There was a lot of unnecessary nesting which made the code harder to read. I also moved a lot of code out of the try/catch blocks because the try/catch blocks are intended to catch errors in the HTTP requests, not the general code. Additionally, the try catch blocks do not handle errors, so small code mistakes will go unnoticed. I added TODOs to the try/catch blocks to handle errors explicitly because I suspect that weeding the possible exceptions out of the HTTP library will take some time. 

5) **I added a handler for the `InterruptionException` thrown by `Thread.sleep()`**
This will allow for the thread to shutdown gracefully if asked by the runtime.


