### PR TITLE
Update Mesquite_Starter.bat

### DIFF
--- a/Executables/All OSs - Scripts, Options, and Instructions to Users/Windows/RunningOptions/Mesquite_Starter.bat
+++ b/Executables/All OSs - Scripts, Options, and Instructions to Users/Windows/RunningOptions/Mesquite_Starter.bat
@@ -1,1 +1,7 @@
-java --add-opens java.base/java.net=ALL-UNNAMED -Xmx4000M -Xss8m -Djava.library.path=lib -Djri.ignore.ule="yes" -jar Mesquite.jar
+start "" javaw ^
+  --add-opens java.base/java.net=ALL-UNNAMED ^
+  -Xmx2000M -Xss16m ^
+  -Djava.library.path=lib ^
+  -Djri.ignore.ule="yes" ^
+  -classpath "Mesquite_Starter.exe;.;Mesquite_Folder" ^
+  start.Mesquite


### PR DESCRIPTION
On windows systems where Java is in the PATH but not installed from Oracle, Mesquite_Starter.exe fails to find the Java environment and refuses to start Mesquite. This is interpreted that Mesquite_Starter.exe is based on Launch4j v3.14, which seeks information from the registry and fails to find Java, even if the java fulfill the required version, for example those from openjdk or microsoft. (The Launch4j v3.50 news mentions this, and updating Launch4j is expected to make the exe work in more diverse environments).

On such systems, Mesquite can be executed from a command line or batch file. However, with the example bat file in the distribution, xml parse related error prevented execution of accompanied apps such as mafft to work.

The key change in this proposal is adding Mesquite_Starter.exe to the classpath, which was found effective to avoid the XML parse errors. The arguments are based on the "Launcher args" described in the debug log file (launch4j.log) created by "Mesquite_Starter.exe --l4j-debug". Therefore the -jar Mesquite.jar are removed and start.Mesquite was added. 